### PR TITLE
Fix serializer initialization in RegisterView

### DIFF
--- a/drf_registration/api/register.py
+++ b/drf_registration/api/register.py
@@ -60,7 +60,7 @@ class RegisterView(CreateAPIView):
     serializer_class = import_string(drfr_settings.REGISTER_SERIALIZER)
 
     def create(self, request, *args, **kwargs):
-        serializer = self.serializer_class(data=request.data)
+        serializer = self.serializer_class(data=request.data, context={'request': request})
         serializer.is_valid(raise_exception=True)
 
         user = serializer.save()


### PR DESCRIPTION
I'm 90% sure this registration flow was working. It could be that
something changed in the implementing class that's causing the
`HyperlinkedIdentityField` error (where the serializer needs the
request in order to prepare absolute URLIs for the REST API response).

Signed-off-by: delano <delano@cpan.org>